### PR TITLE
Tests for jsdiff-console

### DIFF
--- a/bin/spec
+++ b/bin/spec
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -e
+
+mocha --compilers ls:livescript "**/*spec.ls"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "devDependencies": {
     "chai": "3.5.0",
     "david": "^7.0.1",
+    "dim-console": "0.3.1",
     "mocha": "2.4.5"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "description": "Compares JS hashes using JsDiff and outputs the result on the console",
   "devDependencies": {
-    "david": "^7.0.1"
+    "chai": "3.5.0",
+    "david": "^7.0.1",
+    "mocha": "2.4.5"
   },
   "files": [
     "dist"

--- a/spec/async-testing-spec.ls
+++ b/spec/async-testing-spec.ls
@@ -1,0 +1,31 @@
+/*
+
+Feature: asynchronous testing of hashes
+
+  As a developer dealing with hashes produced by my code
+  I want to be able to diff them against expected values asynchronously in my tests
+  So that verifying them in my asynchronous tests is easy and natural.
+
+  - call "jsdiff-console actual, expected, done" to diff the given hash asynchronously
+
+*/
+
+
+require! {
+  '..' : jsdiff-console
+  'chai' : {expect}
+}
+
+
+describe 'async testing of hashes', ->
+
+
+  context 'matching data', (...) ->
+
+    it 'calls the given callback with no error', (done) ->
+      data =
+        first-name: 'Jean-Luc'
+        last-name: 'Picard'
+      jsdiff-console data, data, (err) ->
+        expect(err).to.be.undefined
+        done!

--- a/spec/async-testing-spec.ls
+++ b/spec/async-testing-spec.ls
@@ -14,18 +14,51 @@ Feature: asynchronous testing of hashes
 require! {
   '..' : jsdiff-console
   'chai' : {expect}
+  'dim-console'
 }
 
 
 describe 'async testing of hashes', ->
 
+  after-each ->
+    dim-console.reset!
+
 
   context 'matching data', (...) ->
 
-    it 'calls the given callback with no error', (done) ->
+    before-each (done) ->
       data =
         first-name: 'Jean-Luc'
         last-name: 'Picard'
-      jsdiff-console data, data, (err) ->
-        expect(err).to.be.undefined
+      jsdiff-console data, data, dim-console, (@err) ~>
         done!
+
+    it 'calls the given callback with no error', ->
+      expect(@err).to.be.undefined
+
+
+    it 'prints no console output', ->
+      expect(dim-console.output).to.equal ''
+
+
+
+  context 'mismatching data', (...) ->
+
+    before-each (done) ->
+      expected =
+        first-name: 'Jean-Luc'
+        last-name: 'Picard'
+      actual =
+        first-name: 'Captain'
+        last-name: 'Picard'
+      jsdiff-console actual, expected, dim-console, (@err) ~>
+        done!
+
+    it 'calls the given callback with an error', ->
+      expect(@err).to.equal 'mismatching records'
+
+
+    it 'prints a diff on the console', ->
+      expect(dim-console.output).to.contain 'Mismatching data!'
+      expect(dim-console.output).to.contain '"firstName": "Jean-Luc"'
+      expect(dim-console.output).to.contain '"firstName": "Captain"'

--- a/spec/async-testing-spec.ls
+++ b/spec/async-testing-spec.ls
@@ -36,7 +36,6 @@ describe 'async testing of hashes', ->
     it 'calls the given callback with no error', ->
       expect(@err).to.be.undefined
 
-
     it 'prints no console output', ->
       expect(dim-console.output).to.equal ''
 
@@ -56,7 +55,6 @@ describe 'async testing of hashes', ->
 
     it 'calls the given callback with an error', ->
       expect(@err).to.equal 'mismatching records'
-
 
     it 'prints a diff on the console', ->
       expect(dim-console.output).to.contain 'Mismatching data!'

--- a/src/jsdiff-console.ls
+++ b/src/jsdiff-console.ls
@@ -4,7 +4,7 @@ require! {
 }
 
 
-log-differences = (differences) ->
+log-differences = (differences, {console, process} = {console, process}) ->
   console.log red '\nxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
   console.log red 'Mismatching data!\n'
   for part in differences
@@ -17,12 +17,13 @@ log-differences = (differences) ->
 
 
 
-module.exports = (actual, expected, done) ->
+module.exports = (actual, expected, output, done) ->
   | !actual    =>  throw new Error "JsDiffConsole: parameter 2 is falsy"
   | !expected  =>  throw new Error "JsDiffConsole: parameter 1 is falsy"
+  | !done      =>  done = output
   differences = diff.diffJson expected, actual
   if differences.length is 1
    done!
   else
-    log-differences differences
+    log-differences differences, output
     done 'mismatching records'


### PR DESCRIPTION
@alexdavid

Hey Alex, what do you think about this approach of testing a library that outputs to console?

I tried using https://github.com/doowb/capture-stream before, but it also swallows all output to the console, including output from the test framework during testing, so that seemed brittle. So here I inject the console as a dependency, via an optional argument of the public API of this library.