### PR TITLE
Promise API

### DIFF
--- a/spec/promises-spec.ls
+++ b/spec/promises-spec.ls
@@ -6,7 +6,8 @@ Feature: testing with promises
   I want to be able to utilize my test framework's ability to handle promises
   So that I don't have to deal with async callbacks unnecessarily.
 
-  - call "jsdiff-console actual, expected" to have jsdiff return a promise
+  - call "jsdiff-console actual, expected" without a callback
+    to receive a promise with the test result
 
 */
 

--- a/spec/promises-spec.ls
+++ b/spec/promises-spec.ls
@@ -1,0 +1,63 @@
+/*
+
+Feature: testing with promises
+
+  As a developer having a lot of synchronous test code
+  I want to be able to utilize my test framework's ability to handle promises
+  So that I don't have to deal with async callbacks unnecessarily.
+
+  - call "jsdiff-console actual, expected" to have jsdiff return a promise
+
+*/
+
+
+require! {
+  '..' : jsdiff-console
+  'chai' : {expect}
+  'chalk' : {green, grey, red}
+}
+
+
+describe 'returning promises', ->
+
+
+  context 'matching data', (...) ->
+
+    before-each ->
+      data =
+        first-name: 'Jean-Luc'
+        last-name: 'Picard'
+      @result = jsdiff-console data, data
+
+    it 'returns a promise', ->
+      expect(@result).to.be.a 'Promise'
+
+    it 'the promise fulfills', (done) ->
+      @result.then done
+
+
+  context 'mismatching data', (...) ->
+
+    before-each !->
+      expected =
+        first-name: 'Jean-Luc'
+        last-name: 'Picard'
+      actual =
+        first-name: 'Captain'
+        last-name: 'Picard'
+      @result = jsdiff-console actual, expected
+
+    it 'returns a promise', ->
+      expect(@result).to.be.a 'Promise'
+
+
+    it 'the promise rejects', (done) ->
+      @result.catch (err) ->
+        expect(err).to.equal "
+          mismatching records:\n\n
+          #{grey  '{\n'}
+          #{red   '  "firstName": "Jean-Luc",\n'}
+          #{green '  "firstName": "Captain",\n'}
+          #{grey  '  "lastName": "Picard"\n}'}
+          "
+        done!

--- a/src/jsdiff-console.ls
+++ b/src/jsdiff-console.ls
@@ -16,9 +16,15 @@ get-color = (part) ->
 module.exports = (actual, expected, done) ->
   | !actual    =>  throw new Error "JsDiffConsole: parameter 2 is falsy"
   | !expected  =>  throw new Error "JsDiffConsole: parameter 1 is falsy"
-  | !done      =>  done = output ; output = undefined
   differences = diff.diffJson expected, actual
   if differences.length is 1
-   done!
+    if done
+      done!
+    else
+      new Promise (fulfill, reject) -> fulfill!
   else
-    done "mismatching records:\n\n#{render-differences differences}"
+    if done
+      done "mismatching records:\n\n#{render-differences differences}"
+    else
+      new Promise (fulfill, reject) ->
+        reject "mismatching records:\n\n#{render-differences differences}"


### PR DESCRIPTION
@alexdavid @charlierudolph

This PR adds a promise API to `jsdiffConsole`.
This makes it easier to use it in workflows that use promises, or to avoid callbacks in tests when they aren't really needed.

This is the first time I'm using promises, so please let me know if this is completely off, or unnecessarily complicated.

I'm going ahead and ship this so that I can start using it, but please add comments nonetheless!